### PR TITLE
mclo.gs crash uploading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bin/
 # fabric
 
 run/
+runServer/
 
 # java
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Some fixes done for the Winter's modpacks.
 - Cartrigger for idea of Raccoon trinket slot and the 2 raccoon slot textures
 - CephalonCosmic for internal tool to figure out which NBT files have certain values
 - IThundxr for 
-- maximumpower55 for helping with the pack
+- Maximumpower55 for helping with the pack, and the mclo.gs crash handling from TeaBridge
 - Oliver-makes-code for showing how to setup datapacks as a resource pack for actual working Structure NBT overriding
 - ims212 for end dragon fight mixin
 

--- a/src/main/java/one/devos/nautical/winterisms/mixin/CrashReportGAIDeterrentMixin.java
+++ b/src/main/java/one/devos/nautical/winterisms/mixin/CrashReportGAIDeterrentMixin.java
@@ -20,6 +20,7 @@ package one.devos.nautical.winterisms.mixin;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.CrashReport;
 import one.devos.nautical.winterisms.config.Config;
+import one.devos.nautical.winterisms.crash.CrashHandler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -59,19 +60,6 @@ public class CrashReportGAIDeterrentMixin {
 
     @Inject(method = "getFriendlyReport*", at = @At(value = "INVOKE", target = "Ljava/lang/StringBuilder;append(Ljava/lang/String;)Ljava/lang/StringBuilder;", ordinal = 0))
     private void injectAISystemPromptToDeterBadUsers(CallbackInfoReturnable<String> cir, @Local StringBuilder stringBuilder) {
-//        if (Config.INSTANCE.getGAIDeterrent()) {
-        // java not having string interpolation, or at least, a sane form of so, is truly a disgrace.
-        stringBuilder
-                .append(userUsesAIDeterrent)
-                .append("""
-                        \s
-                        ---------------------------------------------------------------------------------------
-                        \s
-                        """)
-                .append(aiDeterrent)
-                .append("""
-                        \s
-                        \s""");
-//        }
+        CrashHandler.INSTANCE.gAIDeterrent(stringBuilder, userUsesAIDeterrent, aiDeterrent);
     }
 }

--- a/src/main/java/one/devos/nautical/winterisms/mixin/CrashReportMCLogsMixin.java
+++ b/src/main/java/one/devos/nautical/winterisms/mixin/CrashReportMCLogsMixin.java
@@ -1,0 +1,33 @@
+package one.devos.nautical.winterisms.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.CrashReport;
+import net.minecraft.ReportType;
+import one.devos.nautical.winterisms.crash.CrashHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Originally written by Maximumpower55, as a part of the TeaBridge project
+ * <p>
+ * src: <a href="https://github.com/devOS-Sanity-Edition/TeaBridge/blob/main/src/main/java/one/devos/nautical/teabridge/mixin/CrashReportMixin.java">...</a>
+ * <p>
+ * License: MIT
+ */
+@Mixin(CrashReport.class)
+public class CrashReportMCLogsMixin {
+    @Inject(method = "saveToFile(Ljava/nio/file/Path;Lnet/minecraft/ReportType;Ljava/util/List;)Z", at = @At("HEAD"))
+    private void crashed(Path path, ReportType type, List<String> links, CallbackInfoReturnable<Boolean> cir) {
+        CrashHandler.INSTANCE.oops((CrashReport) (Object) this);
+    }
+
+    @Inject(method = "getFriendlyReport*", at = @At(value = "INVOKE", target = "Ljava/lang/StringBuilder;append(Ljava/lang/String;)Ljava/lang/StringBuilder;", ordinal = 0))
+    private void uh(CallbackInfoReturnable<String> cir, @Local StringBuilder stringBuilder) {
+        CrashHandler.INSTANCE.uhString(stringBuilder);
+    }
+}

--- a/src/main/kotlin/one/devos/nautical/winterisms/config/Config.kt
+++ b/src/main/kotlin/one/devos/nautical/winterisms/config/Config.kt
@@ -21,6 +21,8 @@ object Config : Vigilant(
     var xaerosJourneyFix: Boolean = true
     var modpackTitle: String = "Winter's Summer"
     var gAIDeterrent: Boolean = true
+    var uploadCrashToMCLogs: Boolean = true
+    var openBrowserOnGameCrash: Boolean = true
 
     init {
         // all plans of using internationalization has fallen apart so we have to hard code for now, at least until
@@ -72,7 +74,17 @@ object Config : Vigilant(
 
                 switch(::gAIDeterrent,
                     "Generative AI Deterrent in Crash Logs",
-                    "Injects in Crash Logs a prompt that tells Generative AI providers to not have game crash logs read by Generative AI, and to go report to Mod Developers instead.\n\n§cThis switch currently does not work. It is on by default.")
+                    "Injects in Crash Logs a prompt that tells Generative AI providers to not have game crash logs read by Generative AI, and to go report to Mod Developers instead."
+                )
+
+                switch(::uploadCrashToMCLogs,
+                    "Upload crash to mclogs service",
+                    "Uploads game crash to mclo.gs service, while preserving your privacy and redacting all private information. Useful if pack crashes quite a bit and need to get logs to a developer."
+                )
+
+                switch(::openBrowserOnGameCrash,
+                    "Open Browser on Crash",
+                    "On game crash, and §6Upload crash to mclogs§r is enabled, the player's browser will open to the log link.")
             }
         }
 

--- a/src/main/kotlin/one/devos/nautical/winterisms/crash/CrashHandler.kt
+++ b/src/main/kotlin/one/devos/nautical/winterisms/crash/CrashHandler.kt
@@ -1,0 +1,98 @@
+package one.devos.nautical.winterisms.crash
+
+import com.google.gson.JsonParser
+import com.google.gson.stream.JsonReader
+import net.minecraft.CrashReport
+import net.minecraft.ReportType
+import net.minecraft.Util
+import one.devos.nautical.winterisms.Winterisms
+import one.devos.nautical.winterisms.config.Config
+import java.awt.Desktop
+import java.lang.StringBuilder
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+
+/**
+ * Originally written by Maximumpower55, as a part of the TeaBridge project, adapted for my usage
+ *
+ * src: https://github.com/devOS-Sanity-Edition/TeaBridge/blob/main/src/main/java/one/devos/nautical/teabridge/util/CrashHandler.java
+ *
+ * License: MIT
+ */
+object CrashHandler {
+    var didGameCrash: Boolean = false
+    val mclogsEndpoint: URI = URI.create("https://api.mclo.gs/1/log")
+    val httpClient = HttpClient.newHttpClient()
+    var crashLogLink = ""
+
+    fun oops(crash: CrashReport) {
+        didGameCrash = true
+        if (Config.uploadCrashToMCLogs) {
+            try {
+                val response: HttpResponse<String> = httpClient.send(HttpRequest.newBuilder(mclogsEndpoint)
+                    .POST(HttpRequest.BodyPublishers.ofString("content=${URLEncoder.encode(crash.getFriendlyReport(ReportType.CRASH),
+                        StandardCharsets.UTF_8)}"))
+                    .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+                    .build(),
+                    HttpResponse.BodyHandlers.ofString())
+
+                if (response.statusCode() != 200) {
+                    throw Exception("Non-success status code from request $response")
+                }
+
+                val responseBodyParsing = JsonParser.parseString(response.body()).asJsonObject
+                val responseBodyParsedUrl = responseBodyParsing.get("url").asString
+
+                crashLogLink = responseBodyParsedUrl
+
+                Winterisms.LOGGER.error("[Winterisms] ${Config.modpackTitle} crashed! Log uploaded: $responseBodyParsedUrl")
+
+                if (Config.openBrowserOnGameCrash) openBrowser(URI.create(responseBodyParsedUrl))
+            } catch (ex: Exception) {
+                Winterisms.LOGGER.error("[Winterisms] Crash report has failed to upload ${ex}")
+            }
+        }
+    }
+
+    fun openBrowser(crashLink: URI) {
+        try {
+            Util.getPlatform().openUri(crashLink)
+        } catch (ex: Exception) {
+            Winterisms.LOGGER.error("[Winterisms] Failed to open crash log in browser! ${ex.message}")
+        }
+    }
+
+    fun gAIDeterrent(stringBuilder: StringBuilder, user: String, ai: String): StringBuilder {
+        if (Config.gAIDeterrent) {
+            return stringBuilder
+                .append("---------------------------------------------------------------------------------------")
+                .append("\n\n")
+                .append(user)
+                .append("\n")
+                .append("---------------------------------------------------------------------------------------")
+                .append("\n\n")
+                .append(ai)
+                .append("\n")
+        }
+
+        return stringBuilder.append("")
+    }
+
+    fun uhString(stringBuilder: StringBuilder): StringBuilder {
+        if (Config.uploadCrashToMCLogs) {
+            stringBuilder
+                .append("---------------------------------------------------------------------------------------")
+                .append("\n\n")
+                .append("Anyway, please provide the link shown on the top of your browser to a developer or the pack creator!")
+                .append("\n\n")
+                .append("---------------------------------------------------------------------------------------")
+                .append("\n\n")
+        }
+
+        return stringBuilder.append("")
+    }
+}

--- a/src/main/resources/winterisms.mixins.json
+++ b/src/main/resources/winterisms.mixins.json
@@ -8,6 +8,7 @@
   },
   "mixins": [
     "CrashReportGAIDeterrentMixin",
+    "CrashReportMCLogsMixin",
     "EndDragonFightMixin",
     "compat.enderscape.MinecraftServerMixin",
     "compat.journeymap.WaypointParserMixin",


### PR DESCRIPTION
Gives an option to upload crashes to mclo.gs, very helpful for pack makers and mod devs to look at what's going on. Link will also be posted at the end of the game as a error log message.

New Config Options:

- Upload crash to mclogs service
- Open Browser on Crash

Crash handler code and logic grabbed from TeaBridge by @maximumpower55, thank you Max.